### PR TITLE
Update chart to use helm release namespace

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: threatstack-agent
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.1.3
 description: A Helm chart for the Threat Stack Cloud Security Agent
 keywords:

--- a/templates/cluster-rolebinding.yaml
+++ b/templates/cluster-rolebinding.yaml
@@ -14,4 +14,4 @@ roleRef:
 subjects: 
 - kind: ServiceAccount
   name: {{ include "threatstack-agent.name" .}}
-  namespace: {{ .Values.rbac.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-args
-  namespace: default
   labels:
     app.kubernetes.io/name: {{ include "threatstack-agent.name" . }}
     helm.sh/chart: {{ include "threatstack-agent.chart" . }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "threatstack-agent.fullname" . }}
-  namespace: {{ .Values.rbac.namespace }}
   labels:
     app.kubernetes.io/name: {{ include "threatstack-agent.name" . }}
     helm.sh/chart: {{ include "threatstack-agent.chart" . }}

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata: 
   name: {{ include "threatstack-agent.name" .}}
-  namespace: {{ .Values.rbac.namespace }}
   labels:
     app.kubernetes.io/name: {{ include "threatstack-agent.name" . }}
     helm.sh/chart: {{ include "threatstack-agent.chart" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,11 +14,9 @@ image:
 
 ### RBAC and namespacing settings for release
 # create              :: If `true`, the chart will generate a service account
-# namespace           :: Override namespace to deploy this chart, as desired
 # serviceAccountName  :: If `rbac.create` is set to `false`, use this as the service account name 
 rbac:
   create: true
-  namespace: "default"
   serviceAccountName: "threatstack-agent"
 
 ### Threat Stack Agent settings


### PR DESCRIPTION
Current version of chart does not make use of helm namespace argument as expected. Update chart to fully use `--namespace` argument supplied on helm command line and not require `rbac.namespace` to be passed in.

Increment chart version to 1.0.1

Also fixes hardcoded default namespace for the ConfigMap

Signed-off-by: Matthew DeVenny <matt@boxboat.com>