### PR TITLE
Update default nodeSelector to help with helm 3 compatibility

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: threatstack-agent
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.2.0
 description: A Helm chart for the Threat Stack Cloud Security Agent
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,4 +13,3 @@ sources:
 maintainers:
 - name: Threat Stack Inc.
   email: support@threatstack.com
-

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,3 +13,4 @@ sources:
 maintainers:
 - name: Threat Stack Inc.
   email: support@threatstack.com
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following kubernetes objects are created:
   * clusterrolebindings
   * roles
   * rolebindings
-* A daemonset that installs the threatstack agent container on each node (1 container per node). It defaults to only deploying on nodes where a label `threatstack-agent` is set to `true` (this can be overridden via a `values.yaml`).
+* A daemonset that installs the threatstack agent container on each node (1 container per node). It defaults to deploying on all nodes (this can be overridden via a `values.yaml`).
 * A replicaset to deploy a specially configured threatstack-agent container that communicates with the kubernetes control plane.
 * A Secret to store [sensitive agent configuration](#additional-installation-notes)
 * A ConfigMap will be created to store the Threat Stack agent's setup and runtime configuration options.

--- a/values.yaml
+++ b/values.yaml
@@ -143,12 +143,11 @@ daemonset:
   #      cpu: "200m"
 
   # Override agent's default target nodes
-  # Default is to only deploy on nodes that have the label `threatstack-agent=true`
+  # Default is all nodes within the target namespace
   #
-  # Set these as desired to only install agent on a subset of your kubernetes nodes,
-  # or to {} to deploy to all nodes in the target namespace
-  nodeSelector:
-    threatstack-agent: "true"
+  # Set these as desired to only install agent on a subset of your kubernetes nodes.
+  nodeSelector: {}
+    # threatstack-agent: "true"
   # Optional
   affinity: {}
   # Optional


### PR DESCRIPTION
Helm 3 has [a bug](https://github.com/helm/helm/issues/5184) that prevents null overrides from working correctly. That makes it impossible to properly remove the `nodeSelector` from the daemonset and deploy the agent to all nodes.

By adjusting the default to deploy to all nodes, then we can work around this bug until it is fixed.