### PR TITLE
Add eks default custom cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following values settings for the helm chart are important to note, or expec
 * `image.version`         :: The docker tag for the container image to install. It defaults to Threat Stack's latest offical docker image version for the agent at the time the chart was released. **NOTE:** Changing this could lead to pulling an unofficial, incorrect, or incompatible image, and is strongly discouraged.
 * `gkeContainerOs`        :: If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on GKE with ContainerOS nodes. Defaults to `false`
 * `gkeUbuntu`             :: If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on GKE with Ubuntu nodes. Defaults to `false`
+* `eksAmazon2`            :: If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on EKS with Amazon Linux 2 nodes. Defaults to `false`
 * `customDaemonsetCmd`    :: Uncomment the `command` and `args` sub-attributes, and define them as desired to run custom commands in the daemonset.
 >>>
 **Warning:** Setting `customDaemonsetCmd` improperly can result in the Threat Stack agent not running correctly

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -62,6 +62,9 @@ spec:
 {{- if eq .Values.gkeUbuntu true }}
 {{ toYaml .Values.gkeUbuntuCmd | indent 8 }}
 {{- end }}
+{{- if .Values.eksAmazon2 true }}
+{{ toYaml .Values.eksAmazon2Cmd | indent 8 }}
+{{- end }}
 {{- if .Values.customDaemonsetCmd }}
 {{ toYaml .Values.customDaemonsetCmd | indent 8 }}
 {{- end }}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -62,7 +62,7 @@ spec:
 {{- if eq .Values.gkeUbuntu true }}
 {{ toYaml .Values.gkeUbuntuCmd | indent 8 }}
 {{- end }}
-{{- if .Values.eksAmazon2 true }}
+{{- if eq .Values.eksAmazon2 true }}
 {{ toYaml .Values.eksAmazon2Cmd | indent 8 }}
 {{- end }}
 {{- if .Values.customDaemonsetCmd }}

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,12 @@ gkeUbuntuCmd:
   command: ["bash"]
   args: ["-c", "chroot /threatstackfs /bin/bash -c 'systemctl stop auditd; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
 
+# Using EKS Amazon Linux 2 nodes
+eksAmazon2: false
+eksAmazon2Cmd:
+  command: ["bash"]
+  args: ["-c", "chroot /threatstackfs /bin/bash -c 'service auditd stop; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
+
 # Uncomment and set child attributes to execute custom commands in your container
 customDaemonsetCmd: {}
   # command: [""]


### PR DESCRIPTION
Added a common command I have to add when deploying to EKS with AL2-based worker node groups.

NOTE: double-checked that linting passes with these changes -
```
$ helm lint .
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```
