### PR TITLE
move security context to values file

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -99,7 +99,7 @@ spec:
                 name: {{ include "threatstack-agent.name" . }}-config-args
                 key: config-args
         securityContext:
-          privileged: false
+          {{- toYaml .Values.daemonset.securityContext | nindent 10 }}
           capabilities:
             add: {{ .Values.capabilities | trim }}
 {{- if .Values.daemonset.resources }}

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -82,7 +82,7 @@ spec:
                 name: {{ include "threatstack-agent.name" . }}-config-args
                 key: kubernetes-api-config-args
         securityContext:
-          privileged: false
+          {{- toYaml .Values.apiReader.securityContext | nindent 10 }}
           capabilities:
             add: {{ .Values.capabilities | trim }}
 {{- if .Values.apiReader.resources }}

--- a/values.yaml
+++ b/values.yaml
@@ -119,7 +119,6 @@ apiReader:
   #    limits:
   #      memory: "512Mi"
   #      cpu: "400m"
-
   # Override kubernetes api reader agent's default target nodes
   # Default is any node within the target namespace
   #
@@ -131,6 +130,9 @@ apiReader:
   affinity: {}
   # Optional
   tolerations: []
+
+  securityContext:
+    privileged: false
 
 ########
 #
@@ -241,3 +243,6 @@ daemonset:
   #     the end
   #
   customLuaFilter: ""
+
+  securityContext:
+    privileged: false


### PR DESCRIPTION
At my organization, we are looking to define some additional container security context as it relates to the daemonset and api reader. In an effort to allow us to do that, while still providing the same functionality for users today, I migrated the default security context to the values file, which will allow us to make the additional customizations. FYI what were looking to do is add `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false`, but didn't feel that was appropriate to drive your internal roadmap with setting them as default. 