### PR TITLE
Redeployment enhancements

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: threatstack-agent
-version: 2.3.0
+version: 2.4.0
 appVersion: 2.5.0
 description: A Helm chart for the Threat Stack Cloud Security Agent
 keywords:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -22,9 +22,16 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
       name: {{ include "threatstack-agent.name" . }}
       annotations:
-      {{- if .Values.daemonset.podAnnotations }}
+        # If configmap or secret files change, this will change the checksum annotations in the daemonset, forcing a redeploy.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if not .Values.agentSetupExternalSecretRef }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- else }}
+        checksum/secrets: {{ .Values.agentSetupExternalSecretRef.checksum | sha256sum }}
+{{- end }}
+{{- if .Values.daemonset.podAnnotations }}
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
-      {{- end }}
+{{- end }}
     spec:
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -23,11 +23,13 @@ spec:
       name: {{ include "threatstack-agent.name" . }}
       annotations:
         # If configmap or secret files change, this will change the checksum annotations in the daemonset, forcing a redeploy.
+        # If using an external secret reference, then if external secret name or entry change, but NOT the actual secret data,
+        # this will change the checksum annotations in the deployment, forcing a redeploy.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if not .Values.agentSetupExternalSecretRef }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
 {{- else }}
-        checksum/secrets: {{ .Values.agentSetupExternalSecretRef.checksum | sha256sum }}
+        checksum/secrets: {{ .Values.agentSetupExternalSecretRef | toString | sha256sum }}
 {{- end }}
 {{- if .Values.daemonset.podAnnotations }}
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -23,12 +23,17 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
       name: {{ include "threatstack-agent.name" .}}-kubernetes-api
       annotations:
-        # If configmap or secret files change, this will change the checksum annotations in the daemonset, forcing a redeploy.
+        # If configmap or secret files change, this will change the checksum annotations in the deployment, forcing a redeploy.
+        # If using an external secret reference, then if external secret name or entry change, but NOT the actual secret data,
+        # this will change the checksum annotations in the deployment, forcing a redeploy.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if not .Values.agentSetupExternalSecretRef }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
 {{- else }}
-        checksum/secrets: {{ .Values.agentSetupExternalSecretRef.checksum | sha256sum }}
+        checksum/secrets: {{ .Values.agentSetupExternalSecretRef | toString | sha256sum }}
+{{- end }}
+{{- if .Values.apiReader.podAnnotations }}
+{{ toYaml .Values.apiReader.podAnnotations | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.imagePullSecrets }}
@@ -50,6 +55,9 @@ spec:
       tolerations:
 {{ toYaml .Values.apiReader.tolerations | indent 8 }}
 {{- else }}
+{{- end }}
+{{- if .Values.apiReader.priorityClassName }}
+      priorityClassName: {{ .Values.apiReader.priorityClassName }}
 {{- end }}
       hostNetwork: true
       hostPID: true

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -23,6 +23,13 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
       name: {{ include "threatstack-agent.name" .}}-kubernetes-api
       annotations:
+        # If configmap or secret files change, this will change the checksum annotations in the daemonset, forcing a redeploy.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if not .Values.agentSetupExternalSecretRef }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- else }}
+        checksum/secrets: {{ .Values.agentSetupExternalSecretRef.checksum | sha256sum }}
+{{- end }}
     spec:
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -131,6 +131,22 @@ apiReader:
   # Optional
   tolerations: []
 
+  # Optional
+  # Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  ## Annotations to add to the threatstack api reader agent pod
+  #
+  # To remove the apparmor annotation, add a comment as the attribute value,
+  # Example:
+  #   podAnnotations:
+  #     # This comment triggers REMOVING any podAnnotations!
+  #
+  # podAnnotations:
+  #   key: "value"
+  # Optional
+  podAnnotations: {}
+
   securityContext:
     privileged: false
 


### PR DESCRIPTION
This PR mainly allows for helm to recognize instances where configuration has changed, and therefore trigger a redeployment of the DaemonSet and Deployment pods. Also brought over a few more values from the DaemonSet to the Deployment, for parity's sake, and updated documentation.