### PR TITLE
Backwards incompatible change: Changed capabilities definition to yaml list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following kubernetes objects are created when the chart is installed:
 | apiReader.tolerations | list | `[]` |  |
 | apiReader.podAnnotations | string | {} |  |
 | apiReader.priorityClassName | string | `""` | Optionally set the priority class name for the daemonset pods. Note that priority classes are not created via this helm chart. Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |
-| capabilities | string | `"[\"AUDIT_CONTROL\", \"SYS_ADMIN\", \"SYS_PTRACE\"]\n"` | Docker capabilites required for the proper operation of the agent |
+| capabilities | list | `["AUDIT_CONTROL", "SYS_ADMIN", "SYS_PTRACE"]` | Docker capabilites required for the proper operation of the agent |
 | customDaemonsetCmd | object | `{}` | Uncomment the `command` and `args` sub-attributes, and define them as desired to run custom commands in the daemonset. |
 | daemonset.additionalRuntimeConfig | string | `"log.level info"` |  |
 | daemonset.affinity | object | `{}` |  |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -32,6 +32,26 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return capabilities required for daemonset agent pods
+*/}}
+{{- define "threatstack-agent.daemonset-capabilities" -}}
+{{- $ebpf_caps := list "SYS_RESOURCE" "IPC_LOCK" -}}
+{{- if .Values.ebpfEnabled -}}
+{{- $cap_list := concat .Values.capabilities $ebpf_caps -}}
+{{- range $cap_list -}}"{{- . -}}", {{ end -}}
+{{- else -}}
+{{- range .Values.capabilities -}}"{{- . -}}", {{ end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return capabilities required for api-reader pod
+*/}}
+{{- define "threatstack-agent.apireader-capabilities" -}}
+{{- range .Values.capabilities -}}"{{- . -}}", {{ end -}}
+{{- end -}}
+
+{{/*
 Return runtime config if docker is disabled
 */}}
 {{- define "threatstack-agent.docker-config" -}}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
         securityContext:
           {{- toYaml .Values.daemonset.securityContext | nindent 10 }}
           capabilities:
-            add: {{ .Values.capabilities | trim }}
+            add: [{{ include "threatstack-agent.daemonset-capabilities" . | trimSuffix ", " }}]
 {{- if .Values.daemonset.resources }}
         resources:
 {{ toYaml .Values.daemonset.resources | trim | indent 10 }}
@@ -141,6 +141,14 @@ spec:
             mountPath: /opt/threatstack/etc/tsauditd-custom.lua
             subPath: tsauditd-custom.lua
 {{- end }}
+{{- if .Values.ebpfEnabled }}
+          - name: kernel-debug
+            mountPath: /sys/kernel/debug
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: bpf
+            mountPath: /sys/fs/bpf
+{{- end }}
       volumes:
         - hostPath:
             path: /
@@ -168,4 +176,15 @@ spec:
             items:
               - key: custom-luafilter-content
                 path: tsauditd-custom.lua
+{{- end }}
+{{- if .Values.ebpfEnabled }}
+        - hostPath:
+            path: /sys/kernel/debug
+          name: kernel-debug
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroup
+        - hostPath:
+            path: /sys/fs/bpf
+          name: bpf
 {{- end }}

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -99,7 +99,7 @@ spec:
         securityContext:
           {{- toYaml .Values.apiReader.securityContext | nindent 10 }}
           capabilities:
-            add: {{ .Values.capabilities | trim }}
+            add: [{{ include "threatstack-agent.apireader-capabilities" . | trimSuffix ", " }}]
 {{- if .Values.apiReader.resources }}
         resources:
 {{ toYaml .Values.apiReader.resources | trim | indent 10 }}

--- a/templates/pod-security-policy.yaml
+++ b/templates/pod-security-policy.yaml
@@ -19,6 +19,14 @@ spec:
       readOnly: false
     - pathPrefix: "/run/containerd/containerd.sock"
       readOnly: false
+{{- if .Values.daemonset.ebpfEnabled }}
+    - pathPrefix: "/sys/kernel/debug"
+      readOnly: false
+    - pathPrefix: "/sys/fs/cgroup"
+      readOnly: false
+    - pathPrefix: "/sys/fs/bpf"
+      readOnly: false
+{{- end }}
   hostNetwork: true
   hostPID: true
   seLinux:

--- a/values.yaml
+++ b/values.yaml
@@ -46,10 +46,14 @@ rbac:
 #
 # rulesets              :: Define what rules will be applied to the agent by default
 # additionalSetupConfig :: Additional parameters passed to the backend during initial agent registration
-# additionalConfig      :: Additional parameters to configure the running agent
 # capabilities          :: Docker capabilites required for the proper operation of the agent
-capabilities: |
-  ["AUDIT_CONTROL", "SYS_ADMIN", "SYS_PTRACE", "SYS_NICE"]
+rulesets: "Base Rule Set, Docker Rule Set, Kubernetes Rule Set"
+additionalSetupConfig: ""
+capabilities:
+  - AUDIT_CONTROL
+  - SYS_ADMIN
+  - SYS_PTRACE
+  - SYS_NICE
 
 #####
 # WARNING!
@@ -62,8 +66,6 @@ capabilities: |
 #####
 agentDeployKey: ""
 
-rulesets: "Base Rule Set, Docker Rule Set, Kubernetes Rule Set"
-additionalSetupConfig: ""
 
 #####
 #


### PR DESCRIPTION
* The chart now uses a yaml list instead of a string to define container system capabilities.
  * Docs have been updated, and 2 new helper functions have been added to output the correct format in the daemonset and api-reader templates.
* Added some additional templating for new agent features