### PR TITLE
Added HostToContainer mount propagation for hostfs

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -126,6 +126,7 @@ spec:
         volumeMounts:
           - name: hostfs
             mountPath: /threatstackfs
+            mountPropagation: HostToContainer
             readOnly: true
 {{- if .Values.daemonset.customAuditRules }}
           - name: custom-audit-rules


### PR DESCRIPTION
Added HostToContainer mount propagation for hostfs so new containerd overlay mounts are visible to threatstack.