### PR TITLE
Adjust capabilities list formatting

### DIFF
--- a/templates/pod-security-policy.yaml
+++ b/templates/pod-security-policy.yaml
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  allowedCapabilities: {{ .Values.capabilities | trim }}
+  allowedCapabilities: [{{ include "threatstack-agent.apireader-capabilities" . | trimSuffix ", " }}]
   allowedHostPaths:
     - pathPrefix: "/"
       readOnly: false


### PR DESCRIPTION
The capabilites format used in PodSecurityPolicy is in the old version of some version of the helm chart.
This PR corrects the format to follow what is being defined in the DaemonSet.