### PR TITLE
Improvements in defining arguments to setup tsagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Threat Stack Agent Helm Chart
 
 This project defines the helm chart to deploy the Threat Stack container agent in the recommended configuration for kubernetes.
 
->>>
-**Note:** The chart `version` is independent of the version of the agent packaged/installed by the chart. The default version of the Threat Stack agent to be installed by the helm chart is defined by the helm chart's `appVersion` field.
+> **Note**
+>
+> The chart `version` is independent of the version of the agent packaged/installed by the chart. The default version of the Threat Stack agent to be installed by the helm chart is defined by the helm chart's `appVersion` field.
 
 Because agent updates and improvements from version to version can require backwards-incompatible chart changes, *we do not recommend customers override the agent version*.
->>>
 
 This chart installs the agent in the recommended configuration for kubernetes clusters. Configuration values should be overridden by passing helm one or more yaml files of overrides. See [Additional Installation Notes](#additional-installation-notes) section for specific recommendations. For a full list of values defined for this chart, see the `values.yaml` in this repository.
 
@@ -62,16 +62,16 @@ The following kubernetes objects are created when the chart is installed:
 | ebpfEnabled | bool | `false` | Enables using ebpf-based monitoring where applicable. With some workloads, an increase in resource usage by the agent has been seen, so you may need to increase cpu and/or memory limits when enabling eBPF sensors |
 | eksAmazon2 | bool | `false` | If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on EKS with Amazon Linux 2 nodes. Defaults to `false` |
 | eksAmazon2Cmd.args[0] | string | `"-c"` |  |
-| eksAmazon2Cmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'service auditd stop; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
+| eksAmazon2Cmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'service auditd stop; systemctl disable auditd'; eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
 | eksAmazon2Cmd.command[0] | string | `"bash"` |  |
 | fullnameOverride | string | `""` |  |
 | gkeContainerOs | bool | `false` | If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on GKE with ContainerOS node |
 | gkeContainerOsCmd.args[0] | string | `"-c"` |  |
-| gkeContainerOsCmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'systemctl stop systemd-journald-audit.socket; systemctl mask systemd-journald-audit.socket; systemctl restart systemd-journald; auditctl --backlog_wait_time 0'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
+| gkeContainerOsCmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'systemctl stop systemd-journald-audit.socket; systemctl mask systemd-journald-audit.socket; systemctl restart systemd-journald; auditctl --backlog_wait_time 0'; eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
 | gkeContainerOsCmd.command[0] | string | `"bash"` |  |
 | gkeUbuntu | bool | `false` | If `true`, the Daemonset definition will be modified to execute commands for the agent to work correctly on GKE with Ubuntu nodes. Defaults to `false` |
 | gkeUbuntuCmd.args[0] | string | `"-c"` |  |
-| gkeUbuntuCmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'systemctl stop auditd; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
+| gkeUbuntuCmd.args[1] | string | `"chroot /threatstackfs /bin/bash -c 'systemctl stop auditd; systemctl disable auditd'; eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"` |  |
 | gkeUbuntuCmd.command[0] | string | `"bash"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"threatstack/ts-docker2"` | The docker repository for the container image to install. It defaults to Threat Stack's offical docker hub repository for the agent. **NOTE:** Changing this could lead to pulling an unofficial, incorrect, or incompatible image, and is strongly discouraged. |
@@ -89,9 +89,9 @@ The instructions below assume the helm chart has been released to a repository. 
 
 In this, one should not add the helm repository as directed below (step 1), and omit the `--repo https://pkg.threatstack.com/helm` from any command. Also, instead of the chart name being `threatstack-agent`, you should use `<PATH_TO_CHART>/threatstack-agent-<VERSION>.tgz` in helm commands.
 
->>>
-**WARNING:** Creating a local helm chart does not sign the chart package. Any verfication of the provenance of the chart will fail.
->>>
+> **Warning**
+>
+>  Creating a local helm chart does not sign the chart package. Any verfication of the provenance of the chart will fail.
 
 #### Installing publicly released chart
 
@@ -101,8 +101,8 @@ The threatstack agent helm chart follows the standard installation process for c
    ```shell
    > helm repo add threatstack https://pkg.threatstack.com/helm
    ```
-1. Using the default `values.yaml`, create a local yaml that overrides the configuration as desired or needed for the target cluster (See [Additional Installation Notes][#additional-installation-notes] below)
-1. Install the threatstack agent with helm
+2. Using the default `values.yaml`, create a local yaml that overrides the configuration as desired or needed for the target cluster (See [Additional Installation Notes][#additional-installation-notes] below)
+3. Install the threatstack agent with helm
     * `Helm 2:`
    ```shell
    > helm install --name <HELM_RELEASE_NAME> --values ./<values-override-filename>.yaml threatstack/threatstack-agent
@@ -145,30 +145,51 @@ Assuming you override the default values to match our environment in a `values.y
 > helm install --name my-threatstack-agents --values values.yaml --values deploykey-override.yaml threatstack/threatstack-agent
 ```
 
-> **NOTE:** Most of the overridable values for the threatstack agent helm chart are **not** sensitive, and therefore can (and should) be checked into a source control system.
+> **Note**
+>
+> Most of the overridable values for the threatstack agent helm chart are **not** sensitive, and therefore can (and should) be checked into a source control system.
 
 ##### Using the `agentSetupExternalSecretRef` value block
 
->>>
-**IMPORTANT:** Using `agentSetupExternalSecretRef` decouples secret management from the helm chart. Therefore, if the value of the secret changes, the agent DaemonSet and Deployment will _not_ be redeployed/restarted. The user will need to force a redeployment of the helm chart explicitly.
+> **Warning**
+>
+> Using `agentSetupExternalSecretRef` decouples secret management from the helm chart. Therefore, if the value of the secret changes, the agent DaemonSet and Deployment will _not_ be redeployed/restarted. The user will need to force a redeployment of the helm chart explicitly.
 
-However, if the secret's name or secret's entry name changes in the `values.yaml` of the chart, helm will recognize this change with a new release, and trigger a redeployment of the DaemonsSet and Deployment. One way to take advantage of this is to update the secrets entry value name (what is defined at `agentSetupExternalSecretRef.value`) when changing the secret data, and doing a redeploy of the chart. The chart trigger a redeployment of the agent pods.
->>>
+However, if the secret's name or secret's entry name changes in the `values.yaml` of the chart, helm will recognize this change with a new release, and trigger a redeployment of the DaemonsSet and Deployment. One way to take advantage of this is to update the secrets entry value name (what is defined at `agentDeployKey`) when changing the secret data, and doing a redeploy of the chart. The chart trigger a redeployment of the agent pods.
 
-An alternative to having the chart define the `ts-setup-args` secret itself, you can instead have it point to your own self-managed secret. Doing so requires the following three values to be set:
+An alternative to having the chart define secret itself, you can instead have it point to your own self-managed secret. Doing so requires the following three values to be set:
 
-* `agentSetupExternalSecretRef.name`      :: This is the name of your self-managed secret.
-* `agentSetupExternalSecretRef.key`       :: This is the key in your self-managed secret that is associated with the data you want to supply from the secret, to the Threat Stack agent setup registration.
+* `agentSetupExternalSecretRef.name`      : This is the name of your self-managed secret.
+* `agentSetupExternalSecretRef.key`       : This is the key in your self-managed secret that is associated with the data you want to supply from the secret, to the Threat Stack agent setup registration.
+
+E.g:
+```yaml
+# self-managed secret spec
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tsagent-setup-key
+type: Opaque
+stringData:
+  value: "foo"
+```
+
+```yaml
+# values.yaml
+...
+
+agentSetupExternalSecretRef:
+   name: tsagent-setup-key
+   key: value
+...
+```
 
 Do not set the `agentSetupExternalSecretRef` block *and* the `agentDeployKey` settings at the same time. This will cause unnecessary kubernetes resource definitions to be created. If you had previously used the `agentDeployKey` value, the secret associated with it may be destroyed on deployment.
 
-Using the `agentSetupExternalSecretRef` block will cause the chart to ignore the `agentDeployKey`, `rulesets`, and `additionalSetupConfig` values defined in `values.yaml` or any other values override file, until existing pods are terminated/rescheduled.
+Using the `agentSetupExternalSecretRef` block will cause the chart to ignore the `agentDeployKey`.
 
-The value defined in the secret by `agentSetupExternalSecretRef.name`/`agentSetupExternalSecretRef.key` should be defined as in the example below to properly setup up the agent. Failure to do so can cause the agent to not properly register itself with the Threat Stack platform.
+The value defined in the secret by `agentSetupExternalSecretRef.name`/`agentSetupExternalSecretRef.key` must be set only with the **Agent key**.
 
-```shell
---deploy-key <your-deploy-key> --ruleset '<your-rulesets>' <additional-setup-configuration>"
-```
 
 ### Contributing enhancements/fixes
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -32,6 +32,7 @@ metadata:
 data:
   config-args: {{ include "threatstack-agent.daemonset-runtimeConfig" . }}
   kubernetes-api-config-args: enable_kubes_master 1 {{ .Values.apiReader.additionalRuntimeConfig }}
+  setup-args: "--ruleset {{ .Values.rulesets | squote }} {{ .Values.additionalSetupConfig }}"
 {{- if .Values.daemonset.customAuditRules }}
   custom-audit-rules-content: {{ toYaml .Values.daemonset.customAuditRules | indent 4 }}
 {{- end }}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -113,17 +113,21 @@ spec:
           failureThreshold: 5
 {{- end }}
         env:
-          - name: THREATSTACK_SETUP_ARGS
+          - name: THREATSTACK_SETUP_DEPLOY_KEY
             valueFrom:
+              secretKeyRef:
 {{- if not .Values.agentSetupExternalSecretRef }}
-              secretKeyRef:
                 name: {{ include "threatstack-agent.fullname" . }}
-                key: ts-setup-args
+                key: ts-setup-deploy-key
 {{- else }}
-              secretKeyRef:
                 name: {{ .Values.agentSetupExternalSecretRef.name }}
                 key: {{ .Values.agentSetupExternalSecretRef.key }}
 {{- end }}
+          - name: THREATSTACK_SETUP_ARGS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "threatstack-agent.name" . }}-config-args
+                key: setup-args
           - name: THREATSTACK_CONFIG_ARGS
             valueFrom:
               configMapKeyRef:

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -102,17 +102,21 @@ spec:
           failureThreshold: 5
 {{- end }}
         env:
-          - name: THREATSTACK_SETUP_ARGS
+          - name: THREATSTACK_SETUP_DEPLOY_KEY
             valueFrom:
+              secretKeyRef:
 {{- if not .Values.agentSetupExternalSecretRef }}
-              secretKeyRef:
                 name: {{ include "threatstack-agent.fullname" . }}
-                key: ts-setup-args
+                key: ts-setup-deploy-key
 {{- else }}
-              secretKeyRef:
                 name: {{ .Values.agentSetupExternalSecretRef.name }}
                 key: {{ .Values.agentSetupExternalSecretRef.key }}
 {{- end }}
+          - name: THREATSTACK_SETUP_ARGS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "threatstack-agent.name" . }}-config-args
+                key: setup-args
           - name: THREATSTACK_CONFIG_ARGS
             valueFrom:
               configMapKeyRef:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -32,5 +32,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 stringData:
-  ts-setup-args: "--deploy-key {{ .Values.agentDeployKey }} --ruleset '{{ .Values.rulesets }}' {{ .Values.additionalSetupConfig }}"
+  ts-setup-deploy-key: {{ .Values.agentDeployKey | quote }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -33,19 +33,40 @@ imagePullSecrets: []
 gkeContainerOs: false
 gkeContainerOsCmd:
   command: ["bash"]
-  args: ["-c", "chroot /threatstackfs /bin/bash -c 'systemctl stop systemd-journald-audit.socket; systemctl mask systemd-journald-audit.socket; systemctl restart systemd-journald; auditctl --backlog_wait_time 0'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
+  args:
+    - -c
+    - >-
+        chroot /threatstackfs /bin/bash -c 'systemctl stop systemd-journald-audit.socket;
+        systemctl mask systemd-journald-audit.socket;
+        systemctl restart systemd-journald; auditctl --backlog_wait_time 0';
+        eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS;
+        eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout
 
 # Using Ubuntu nodes
 gkeUbuntu: false
 gkeUbuntuCmd:
   command: ["bash"]
-  args: ["-c", "chroot /threatstackfs /bin/bash -c 'systemctl stop auditd; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
+  args:
+    - -c
+    - >-
+        chroot /threatstackfs /bin/bash -c 'systemctl stop auditd; systemctl disable auditd';
+        eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS;
+        eval tsagent config --set $THREATSTACK_CONFIG_ARGS;
+        sleep 5;
+        /opt/threatstack/sbin/tsagentd -logstdout
 
 # Using EKS Amazon Linux 2 nodes
 eksAmazon2: false
 eksAmazon2Cmd:
   command: ["bash"]
-  args: ["-c", "chroot /threatstackfs /bin/bash -c 'service auditd stop; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
+  args:
+    - -c
+    - >-
+        chroot /threatstackfs /bin/bash -c 'service auditd stop; systemctl disable auditd';
+        eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS;
+        eval tsagent config --set $THREATSTACK_CONFIG_ARGS;
+        sleep 5;
+        /opt/threatstack/sbin/tsagentd -logstdout
 
 # Uncomment the command and args sub-attributes, and define them as desired to run custom commands in the Daemonset.
 #
@@ -54,7 +75,15 @@ eksAmazon2Cmd:
 # This example turns off and disables auditd running on the host so the container agent can properly monitor activity
 customDaemonsetCmd: {}
   # command: ["bash"]
-  # args: ["-c", "chroot /threatstackfs /bin/bash -c 'service auditd stop >/dev/null || systemctl stop auditd; systemctl disable auditd'; eval tsagent setup $THREATSTACK_SETUP_ARGS; eval tsagent config --set $THREATSTACK_CONFIG_ARGS; sleep 5; /opt/threatstack/sbin/tsagentd -logstdout"]
+  # args:
+  #   - -c
+  #   - >-
+  #       chroot /threatstackfs /bin/bash -c 'service auditd stop >/dev/null || systemctl stop auditd;
+  #       systemctl disable auditd';
+  #       eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS;
+  #       eval tsagent config --set $THREATSTACK_CONFIG_ARGS;
+  #       sleep 5;
+  #       /opt/threatstack/sbin/tsagentd -logstdout
 
 # Use ebpf monitoring where applicable
 # Enabling this setting has been observed to cause an increase in resource usage by the agent with some workloads,


### PR DESCRIPTION
The purpose of this change is to take the complexity out of the basic `tsagent setup` when a user wants to manage the agent key off the chart.

This change decouples the `--deploy-key` argument from the `--ruleset` and additional setup args specified via `values.yaml`, so it doesn't matter whether the graph user uses the `agentDeployKey` or self-managed secret.

It will just need to set its secret with the `agentDeployKey` value. Internally, the graph will be responsible for generating the argument structure for the `tsagent setup` correctly.