### PR TITLE
Standardizing double quotes in the eval command

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -100,7 +100,7 @@ spec:
         args:
           - -c
           - >-
-              eval "tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS" &&
+              eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS &&
               tsagent config --set $THREATSTACK_CONFIG_ARGS &&
               unset THREATSTACK_SETUP_DEPLOY_KEY THREATSTACK_SETUP_ARGS THREATSTACK_CONFIG_ARGS &&
               exec /opt/threatstack/sbin/tsagentd -logstdout=1

--- a/templates/deployment-api-reader.yaml
+++ b/templates/deployment-api-reader.yaml
@@ -92,7 +92,7 @@ spec:
         args:
           - -c
           - >-
-              eval "tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS" &&
+              eval tsagent setup --deploy-key $THREATSTACK_SETUP_DEPLOY_KEY $THREATSTACK_SETUP_ARGS &&
               tsagent config --set $THREATSTACK_CONFIG_ARGS &&
               unset THREATSTACK_SETUP_DEPLOY_KEY THREATSTACK_SETUP_ARGS THREATSTACK_CONFIG_ARGS &&
               exec /opt/threatstack/sbin/tsagentd -logstdout=1


### PR DESCRIPTION
The purpose of this modification is to remove the double quotes from the eval command because when expanding the environment variable `THREATSTACK_SETUP_ARGS`, the string is not expanded correctly

This case was encountered when defining `rulesets`.
The list of `rulesets` in the configmap (which will later be injected as an environment variable in the pod) is not expanding correctly.
Causing the Daemonset initialization command to exit with error and the log message is something like:

![image](https://user-images.githubusercontent.com/29558167/224171575-4f5caab1-6f70-44e8-8a58-e5a64bc34743.png)


Command definition in Values.yaml, for reference: https://github.com/threatstack/threatstack-helm/blob/master/values.yaml#L56